### PR TITLE
5462 added in the UIGraphicsImageRenderer instead of deprecated function

### DIFF
--- a/DynamicBlurView/CGContext+CGImage.swift
+++ b/DynamicBlurView/CGContext+CGImage.swift
@@ -7,18 +7,6 @@
 //
 
 extension CGContext {
-    static func imageContext(with quality: CaptureQuality, rect: CGRect, opaque: Bool) -> CGContext? {
-        UIGraphicsBeginImageContextWithOptions(rect.size, opaque, quality.imageScale)
-        guard let context = UIGraphicsGetCurrentContext() else {
-            return nil
-        }
-
-        context.translateBy(x: -rect.origin.x, y: -rect.origin.y)
-        context.interpolationQuality = quality.interpolationQuality
-
-        return context
-    }
-
     func makeImage(with blendColor: UIColor?, blendMode: CGBlendMode, size: CGSize) -> CGImage? {
         if let color = blendColor {
             setFillColor(color.cgColor)

--- a/DynamicBlurView/DynamicBlurView.swift
+++ b/DynamicBlurView/DynamicBlurView.swift
@@ -135,17 +135,22 @@ open class DynamicBlurView: UIView {
 
     private func snapshotImage(for layer: CALayer, conversion: Bool) -> UIImage? {
         let rect = blurLayerRect(to: layer, conversion: conversion)
-        guard let context = CGContext.imageContext(with: quality, rect: rect, opaque: isOpaque) else {
-            return nil
+        
+        var format = UIGraphicsImageRendererFormat()
+        format.scale = quality.imageScale
+        format.opaque = isOpaque
+        
+        let renderer = UIGraphicsImageRenderer(size: bounds.size, format: format)
+        let image = renderer.image { context in
+            let cgContext = context.cgContext
+            
+            cgContext.translateBy(x: -rect.origin.x, y: -rect.origin.y)
+            cgContext.interpolationQuality = quality.interpolationQuality
+            
+            blurLayer.render(in: cgContext, for: layer)
         }
-
-        blurLayer.render(in: context, for: layer)
-
-        defer {
-            UIGraphicsEndImageContext()
-        }
-
-        return UIGraphicsGetImageFromCurrentImageContext()
+        
+        return image
     }
 }
 


### PR DESCRIPTION
for this card https://myxplorinfo.atlassian.net/browse/PES-5462 in iOS 17 UIGraphicsBeginImageContextWithOptions is deprecated and needs to be replaced with UIGraphicsImageRenderer